### PR TITLE
Refactor validation variables structure

### DIFF
--- a/inventory/local_test/group_vars/all.yml
+++ b/inventory/local_test/group_vars/all.yml
@@ -2,46 +2,48 @@
 ansible_python_interpreter: /usr/bin/python3
 
 validation:
-  # Check if OpenNebula services are running
-  core_services: true
-  # List of services to check enabled, stop and restart
-  service_list:
-    - name: opennebula.service
-      desc: OpenNebula core (oned)
-    - name: opennebula-gate.service
-      desc: OpenNebula gate
-    - name: opennebula-flow.service
-      desc: OpenNebula flow
-  check_fireedge_ui: false
+  run_core_services: true
+  core_services:
+    # List of services to check enabled, stop and restart
+    service_list:
+      - name: opennebula.service
+        desc: OpenNebula core (oned)
+      - name: opennebula-gate.service
+        desc: OpenNebula gate
+      - name: opennebula-flow.service
+        desc: OpenNebula flow
+    check_fireedge_ui: false
   run_storage_benchmark: false
-  run_ha_verifications: false
+  run_fe_ha: false
   run_network_benchmark: true
 
-  create_vnet: true
-  vnet:
-    name: 'test-vnet'
-    desc: 'A test network for post-deployment cloud verification'
-    bridge: 'br-test'
-    vn_mad: 'dummy'
-    phydev: 'eth1'
-    network_address: '192.168.150.100'
-    network_mask: '255.255.255.0'
-    dns: '8.8.8.8'
-    gateway: '192.168.150.1'
-    ar:
-      - type: "IP4"
-        ip: '192.168.150.100'
-        size: '10'
+  run_test_vm: true
+  test_vm:
+    create_vnet: true
+    vnet:
+      name: 'test-vnet'
+      desc: 'A test network for post-deployment cloud verification'
+      bridge: 'br-test'
+      vn_mad: 'dummy'
+      phydev: 'eth1'
+      network_address: '192.168.150.100'
+      network_mask: '255.255.255.0'
+      dns: '8.8.8.8'
+      gateway: '192.168.150.1'
+      ar:
+        - type: "IP4"
+          ip: '192.168.150.100'
+          size: '10'
+    vm:
+      check_connection: false
+      market_name: 'Alpine Linux 3.21'
+      # template_extra: |
+      #   MEMORY="512"
 
   conn_matrix:
     bridge_name: br0
     vnet_name: public
 
-  vm:
-    check_connection: false
-    market_name: 'Alpine Linux 3.21'
-    # template_extra: |
-    #   MEMORY="512"
   run_vm_ha: true
   vm_ha:
     produce_error_method: 'if_down'

--- a/inventory/local_test/group_vars/all.yml
+++ b/inventory/local_test/group_vars/all.yml
@@ -14,11 +14,29 @@ validation:
       desc: OpenNebula flow
   check_fireedge_ui: false
   run_storage_benchmark: false
+  run_ha_verifications: false
   run_network_benchmark: true
-  create_vnet: false
+
+  create_vnet: true
+  vnet:
+    name: 'test-vnet'
+    desc: 'A test network for post-deployment cloud verification'
+    bridge: 'br-test'
+    vn_mad: 'dummy'
+    phydev: 'eth1'
+    network_address: '192.168.150.100'
+    network_mask: '255.255.255.0'
+    dns: '8.8.8.8'
+    gateway: '192.168.150.1'
+    ar:
+      - type: "IP4"
+        ip: '192.168.150.100'
+        size: '10'
+
   conn_matrix:
     bridge_name: br0
     vnet_name: public
+
   vm:
     check_connection: false
     market_name: 'Alpine Linux 3.21'

--- a/inventory/reference/group_vars/all.yml
+++ b/inventory/reference/group_vars/all.yml
@@ -2,9 +2,14 @@
 ansible_python_interpreter: /usr/bin/python3
 
 validation:
+
+  run_ha_verifications: false
+  one_config_path:
+    - /etc/one
+    - /var/lib/one/remotes/etc
+
   # Check if OpenNebula services are running
   core_services: true
-  run_ha_verifications: true 
   # List of services to check enabled, stop and restart
   service_list:
     - name: opennebula.service
@@ -18,15 +23,18 @@ validation:
     #   desc: OpenNebula Scheduler
     - name: opennebula-fireedge.service
       desc: OpenNebula Fireedge GUI
+    # Add other services if more should be checked.
   check_fireedge_ui: true
+  
   run_storage_benchmark: true
   storage_benchmark:
     vnet_name: vxlan
+
   run_network_benchmark: true
   network_benchmark:
     iperf_port: 5201
     iperf_test_time: 10
-  create_vnet: true
+
   conn_matrix:
     bridge_name: br-test
     ping_count: 10
@@ -36,20 +44,23 @@ validation:
     market_name: 'Alpine Linux 3.21'
     template_extra: |
       MEMORY="512"
+  
+  create_vnet: true
   vnet:
-    name: 'VLAN_580'
+    name: 'tes-vnet'
     desc: 'A test network for post-deployment cloud verification'
     bridge: 'br-test'
     vn_mad: 'dummy'
-    phydev: ''
-    network_address: '10.0.0.0'
+    phydev: 'eth1'
+    network_address: '192.168.150.100'
     network_mask: '255.255.255.0'
     dns: '8.8.8.8'
-    gateway: '10.0.0.1'
+    gateway: '192.168.150.1'
     ar:
       - type: "IP4"
-        ip: '10.0.0.10'
+        ip: '192.168.150.100'
         size: '10'
+
   run_vm_ha: false
   vm_ha:
     produce_error_method: 'if_down'

--- a/inventory/reference/group_vars/all.yml
+++ b/inventory/reference/group_vars/all.yml
@@ -3,29 +3,26 @@ ansible_python_interpreter: /usr/bin/python3
 
 validation:
 
-  run_ha_verifications: false
-  one_config_path:
-    - /etc/one
-    - /var/lib/one/remotes/etc
+  run_fe_ha: false
 
-  # Check if OpenNebula services are running
-  core_services: true
-  # List of services to check enabled, stop and restart
-  service_list:
-    - name: opennebula.service
-      desc: OpenNebula core (oned)
-    - name: opennebula-gate.service
-      desc: OpenNebula gate
-    - name: opennebula-flow.service
-      desc: OpenNebula flow
-    # NOTE: Scheduler service is always checked in earlier than 6.99 versions
-    # - name: opennebula-scheduler.service
-    #   desc: OpenNebula Scheduler
-    - name: opennebula-fireedge.service
-      desc: OpenNebula Fireedge GUI
-    # Add other services if more should be checked.
-  check_fireedge_ui: true
-  
+  run_core_services: true
+  core_services:
+    # List of services to check enabled, stop and restart
+    service_list:
+      - name: opennebula.service
+        desc: OpenNebula core (oned)
+      - name: opennebula-gate.service
+        desc: OpenNebula gate
+      - name: opennebula-flow.service
+        desc: OpenNebula flow
+      # NOTE: Scheduler service is always checked in earlier than 6.99 versions
+      # - name: opennebula-scheduler.service
+      #   desc: OpenNebula Scheduler
+      - name: opennebula-fireedge.service
+        desc: OpenNebula Fireedge GUI
+      # Add other services if more should be checked.
+    check_fireedge_ui: true
+
   run_storage_benchmark: true
   storage_benchmark:
     vnet_name: vxlan
@@ -39,27 +36,29 @@ validation:
     bridge_name: br-test
     ping_count: 10
     vnet_name: VLAN_580
-  vm:
-    check_connection: true
-    market_name: 'Alpine Linux 3.21'
-    template_extra: |
-      MEMORY="512"
-  
-  create_vnet: true
-  vnet:
-    name: 'tes-vnet'
-    desc: 'A test network for post-deployment cloud verification'
-    bridge: 'br-test'
-    vn_mad: 'dummy'
-    phydev: 'eth1'
-    network_address: '192.168.150.100'
-    network_mask: '255.255.255.0'
-    dns: '8.8.8.8'
-    gateway: '192.168.150.1'
-    ar:
-      - type: "IP4"
-        ip: '192.168.150.100'
-        size: '10'
+
+  run_test_vm: true
+  test_vm:
+    vm:
+      check_connection: true
+      market_name: 'Alpine Linux 3.21'
+      template_extra: |
+        MEMORY="512"
+    create_vnet: true
+    vnet:
+      name: 'tes-vnet'
+      desc: 'A test network for post-deployment cloud verification'
+      bridge: 'br-test'
+      vn_mad: 'dummy'
+      phydev: 'eth1'
+      network_address: '192.168.150.100'
+      network_mask: '255.255.255.0'
+      dns: '8.8.8.8'
+      gateway: '192.168.150.1'
+      ar:
+        - type: "IP4"
+          ip: '192.168.150.100'
+          size: '10'
 
   run_vm_ha: false
   vm_ha:

--- a/playbooks/cleanup-test-vm-template.yml
+++ b/playbooks/cleanup-test-vm-template.yml
@@ -2,7 +2,7 @@
 - hosts: "{{ frontend_group | d('frontend') }}"
   tasks:
     # Only execute these steps on a single frontend host
-    - when: hostvars[groups[frontend_group | d('frontend')][0]]['ansible_host'] == ansible_host
+    - when: validation.run_test_vm | default(true) and hostvars[groups[frontend_group | d('frontend')][0]]['ansible_host'] == ansible_host
       block:
       - name: Cleanup test template
         ansible.builtin.shell: |
@@ -22,4 +22,4 @@
         ansible.builtin.file:
           path: /tmp/test_vm_template_extra.txt
           state: absent
-        when: validation.vm.template_extra is defined
+        when: validation.test_vm.vm.template_extra is defined

--- a/playbooks/fe-ha.yml
+++ b/playbooks/fe-ha.yml
@@ -3,5 +3,5 @@
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
     - role: fe_ha
-      when: validation.run_ha_verifications == true
+      when: validation.run_fe_ha == true
 

--- a/playbooks/prepare-test-vm-template.yml
+++ b/playbooks/prepare-test-vm-template.yml
@@ -1,7 +1,7 @@
 - hosts: "{{ frontend_group | d('frontend') }}"
   tasks:
       # Only execute these steps on a single frontend host
-      - when: hostvars[groups[frontend_group | d('frontend')][0]]['ansible_host'] == ansible_host
+      - when: validation.run_test_vm | default(true) and hostvars[groups[frontend_group | d('frontend')][0]]['ansible_host'] == ansible_host
         block:
           - name: Download test VM template and image from the Marketplace
             ansible.builtin.shell: |
@@ -32,16 +32,16 @@
 
           - name: Write extra template variables to a temporary file on the remote host
             ansible.builtin.copy:
-              content: "{{ validation.vm.template_extra }}"
+              content: "{{ validation.test_vm.vm.template_extra }}"
               dest: "/tmp/test_vm_template_extra.txt"
-            when: validation.vm.template_extra is defined
+            when: validation.test_vm.vm.template_extra is defined
 
           - name: Update VM template with extra data
             ansible.builtin.shell: >
               onetemplate update --append {{ vm_template_id.stdout }} /tmp/test_vm_template_extra.txt
             register: update_vm_template_extra
             failed_when: update_vm_template_extra.rc != 0
-            when: validation.vm.template_extra is defined
+            when: validation.test_vm.vm.template_extra is defined
 
           - name: Get VM template as JSON
             ansible.builtin.shell: >
@@ -59,3 +59,4 @@
       ansible.builtin.set_fact:
         test_vm_template_id: "{{ hostvars[groups[frontend_group | d('frontend')][0]]['vm_template_id'].stdout }}"
         test_vm_template_image_id: "{{ hostvars[groups[frontend_group | d('frontend')][0]]['vm_template_image_id'] }}"
+      when: validation.run_test_vm | default(true)

--- a/playbooks/tasks/conn_matrix_per_host.yml
+++ b/playbooks/tasks/conn_matrix_per_host.yml
@@ -36,7 +36,7 @@
     onetemplate instantiate {{ test_vm_template_id }} --nic {{ _conn_matrix_vnet_name }} \
       --name conn-mtx-vm-on-host-{{ host_id }} --raw '{{
         (extra_template_content_raw.content | b64decode) +
-        (validation.vm.template_extra if validation.vm.template_extra is defined else "")
+        (validation.test_vm.vm.template_extra if validation.test_vm.vm.template_extra is defined else "")
       }}'
   register: vm_id
   failed_when: "vm_id.rc != 0" 

--- a/playbooks/validation.yml
+++ b/playbooks/validation.yml
@@ -58,6 +58,11 @@
 
 - ansible.builtin.import_playbook: ./conn-matrix.yml
 
+# Run network tests on the hypervisor hosts
+- hosts: "{{ node_group | d('node') }}"
+  roles:
+    - role: network-benchmark
+
 - ansible.builtin.import_playbook: ./vm-ha.yml
 
 - ansible.builtin.import_playbook: ./cleanup-test-vm-template.yml
@@ -74,8 +79,3 @@
     - role: fe_ha
       when: validation.run_ha_verifications == true 
 
-
-# Run network tests on the hypervisor hosts
-- hosts: "{{ node_group | d('node') }}"
-  roles:
-    - role: network-benchmark

--- a/playbooks/validation.yml
+++ b/playbooks/validation.yml
@@ -11,10 +11,11 @@
 
     - name: Set playbook variables for test VM
       set_fact:
-        _test_vm_name: "{{ validation.vm.market_name | d('Alpine Linux 3.21') }}"
+        _test_vm_name: "{{ validation.test_vm.vm.market_name | d('Alpine Linux 3.21') }}"
         # NOTE: Optional parameters, can be overridden in the inventory file
-        # validation.vm.template_extra: |
+        # validation.test_vm.vm.template_extra: |
         #    MEMORY=256
+      when: validation.run_test_vm | default(true)
 
     - name: Save the output of the hostname command to the hostname variable
       ansible.builtin.shell: hostname
@@ -29,6 +30,7 @@
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
     - role: test_vm
+      when: validation.run_test_vm | default(true)
     - role: storage-benchmark
   tasks:
     # Only execute these steps on a single frontend host
@@ -73,9 +75,9 @@
     - role: validation
 
 
-# Run FE HA verfification only when variable run_ha_verifications is set to true
+# Run FE HA verfification only when variable run_fe_ha is set to true
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
     - role: fe_ha
-      when: validation.run_ha_verifications == true 
+      when: validation.run_fe_ha == true
 

--- a/roles/test_vm/defaults/main.yml
+++ b/roles/test_vm/defaults/main.yml
@@ -1,25 +1,26 @@
 ---
 # Vars for the test network
 validation:
-  # Should we create a test network or reuse existing net? Existin network defined in {{validation.vnet.name}} var
-  create_vnet: true
-  vm:
-    check_connection: true
-    market_name: 'Alpine Linux 3.21'
-    template_extra: |
-      MEMORY="512"
-  vnet:
-    name: 'VLAN_580'
-    desc: 'A test network for post-deployment cloud verification'
-    bridge: 'br-test'
-    vn_mad: 'dummy'
-    phydev: ''
-    network_address: '10.0.0.0'
-    network_mask: '255.255.255.0'
-    dns: '8.8.8.8'
-    gateway: '10.0.0.1'
-    ar:
-      - type: "IP4"
-        ip: '10.0.0.10'
-        size: '10'
+  test_vm:
+    # Should we create a test network or reuse existing net? Existin network defined in {{validation.test_vm.vnet.name}} var
+    create_vnet: true
+    vm:
+      check_connection: true
+      market_name: 'Alpine Linux 3.21'
+      template_extra: |
+        MEMORY="512"
+    vnet:
+      name: 'VLAN_580'
+      desc: 'A test network for post-deployment cloud verification'
+      bridge: 'br-test'
+      vn_mad: 'dummy'
+      phydev: ''
+      network_address: '10.0.0.0'
+      network_mask: '255.255.255.0'
+      dns: '8.8.8.8'
+      gateway: '10.0.0.1'
+      ar:
+        - type: "IP4"
+          ip: '10.0.0.10'
+          size: '10'
 

--- a/roles/test_vm/tasks/main.yml
+++ b/roles/test_vm/tasks/main.yml
@@ -1,31 +1,31 @@
 ---
 
 - name: Create vnet
-  when: validation.create_vnet
+  when: validation.test_vm.create_vnet
   block:
     - name: Verify connection to the VNET default gateway
       ansible.builtin.shell: >
-        ping -c 2 {{ validation.vnet.gateway }}
+        ping -c 2 {{ validation.test_vm.vnet.gateway }}
       register: gw_ping_result
       until: gw_ping_result.rc == 0
       retries: 10
       delay: 10
-      when: validation.vm.check_connection
+      when: validation.test_vm.vm.check_connection
 
     - name: Render vnet config
       template:
         src: test_vnet.j2
-        dest: /var/tmp/vnet_{{ validation.vnet.name }}.template
+        dest: /var/tmp/vnet_{{ validation.test_vm.vnet.name }}.template
 
     - name: Create network
       ansible.builtin.shell: >
-        onevnet create /var/tmp/vnet_{{ validation.vnet.name }}.template
+        onevnet create /var/tmp/vnet_{{ validation.test_vm.vnet.name }}.template
       register: test_network
       failed_when: "test_network.rc != 0"
 
     - name: Delete vnet definition
       file:
-        path: /var/tmp/vnet_{{ validation.vnet.name }}.template
+        path: /var/tmp/vnet_{{ validation.test_vm.vnet.name }}.template
         state: absent
 
     - name: Verify test network creation
@@ -65,11 +65,11 @@
     verification_result: "{{ verification_result | combine({'Test VM instantiation' : 'ok' }) }}"
 
 - name: Check connection to VM
-  when: validation.vm.check_connection
+  when: validation.test_vm.vm.check_connection
   block:
   - name: Attach NIC to test VM
     ansible.builtin.shell: >
-      onevm nic-attach -n '{{ validation.vnet.name }}' {{ vm_id.stdout.split(':')[1] | trim }} 
+      onevm nic-attach -n '{{ validation.test_vm.vnet.name }}' {{ vm_id.stdout.split(':')[1] | trim }}
 
   - name: Wait until NIC is attached
     ansible.builtin.shell: >
@@ -115,7 +115,7 @@
 #
 - name: Cleanup created test network
   ansible.builtin.shell: |
-    onevnet delete "{{ validation.vnet.name }}"
+    onevnet delete "{{ validation.test_vm.vnet.name }}"
   register: cleanup_result
   failed_when: "cleanup_result.rc != 0"
-  when: validation.create_vnet and not validation.vm.check_connection
+  when: validation.test_vm.create_vnet and not validation.test_vm.vm.check_connection

--- a/roles/test_vm/templates/test_vnet.j2
+++ b/roles/test_vm/templates/test_vnet.j2
@@ -1,20 +1,20 @@
 # Template for the test network
-NAME        = "{{ validation.vnet.name }}"
-DESCRIPTION = "{{ validation.vnet.desc }}"
+NAME        = "{{ validation.test_vm.vnet.name }}"
+DESCRIPTION = "{{ validation.test_vm.vnet.desc }}"
 
-VN_MAD = {{ validation.vnet.vn_mad }}
-BRIDGE = {{ validation.vnet.bridge | d('br-test') }}
+VN_MAD = {{ validation.test_vm.vnet.vn_mad }}
+BRIDGE = {{ validation.test_vm.vnet.bridge | d('br-test') }}
 
-{% if validation.vnet.phydev is not none %}
-PHYDEV = {{ validation.vnet.phydev }}
+{% if validation.test_vm.vnet.phydev is not none %}
+PHYDEV = {{ validation.test_vm.vnet.phydev }}
 {% endif %}
 
-NETWORK_ADDRESS = {{ validation.vnet.network_address | d('10.0.0.0') }}
-NETWORK_MASK    = {{ validation.vnet.network_mask | d('255.255.255.0') }}
-DNS             = {{ validation.vnet.dns | d('8.8.8.8') }}
-GATEWAY         = {{ validation.vnet.gateway | d('10.0.0.1') }}
+NETWORK_ADDRESS = {{ validation.test_vm.vnet.network_address | d('10.0.0.0') }}
+NETWORK_MASK    = {{ validation.test_vm.vnet.network_mask | d('255.255.255.0') }}
+DNS             = {{ validation.test_vm.vnet.dns | d('8.8.8.8') }}
+GATEWAY         = {{ validation.test_vm.vnet.gateway | d('10.0.0.1') }}
 
-{% for r in validation.vnet.ar %}
+{% for r in validation.test_vm.vnet.ar %}
 AR=[TYPE="{{ r.type }}", IP="{{ r.ip }}", SIZE="{{ r.size }}"]
 {% endfor %}
 

--- a/roles/validation/tasks/core_services_verification.yml
+++ b/roles/validation/tasks/core_services_verification.yml
@@ -31,20 +31,20 @@
   set_fact:
     verification_result: "{{ verification_result | combine({ item.desc + ' is enabled': 'ok'}) }}"
   when: ansible_facts['services'][ item.name ]['status'] | default('not-found') == 'enabled'
-  with_items: "{{ validation.service_list }}"
+  with_items: "{{ validation.core_services.service_list }}"
 
 - name: Check services restart
   ansible.builtin.service:
     name: "{{ item.name }}"
     state: restarted
   register: restarted
-  with_items: "{{ validation.service_list }}"
+  with_items: "{{ validation.core_services.service_list }}"
 
 - name: Check services restarted
   set_fact:
     verification_result: "{{ verification_result | combine({ item.desc + ' restarted': 'ok'}) }}"
   when: ansible_facts['services'][ item.name ]['state'] | default('not-found') == 'running'
-  with_items: "{{ validation.service_list }}"
+  with_items: "{{ validation.core_services.service_list }}"
 
 - name: Check oned version
   ansible.builtin.shell: >
@@ -166,7 +166,7 @@
   - name: Verify connection to a fireedge server
     set_fact:
       verification_result: "{{ verification_result | combine({'Verify connection to a fireedge server' : 'ok'}) }}"
-  when: validation.check_fireedge_ui
+  when: validation.core_services.check_fireedge_ui
 
 - name: Get registered hosts
   ansible.builtin.shell: >

--- a/roles/validation/tasks/main.yml
+++ b/roles/validation/tasks/main.yml
@@ -4,19 +4,21 @@
     validation: >-
       {{
         validation | default({}) | combine({
-          'core_services': validation.core_services | default(true),
-          'service_list': validation.service_list | default([
-            {'name': 'opennebula.service', 'desc': 'OpenNebula core (oned)'},
-            {'name': 'opennebula-gate.service', 'desc': 'OpenNebula gate'},
-            {'name': 'opennebula-flow.service', 'desc': 'OpenNebula flow'},
-            {'name': 'opennebula-fireedge.service', 'desc': 'OpenNebula Fireedge GUI'}
-          ]),
-          'check_fireedge_ui': validation.check_fireedge_ui | default(true)
+          'run_core_services': validation.run_core_services | default(true),
+          'core_services': validation.core_services | default({}) | combine({
+            'service_list': validation.core_services.service_list | default([
+              {'name': 'opennebula.service', 'desc': 'OpenNebula core (oned)'},
+              {'name': 'opennebula-gate.service', 'desc': 'OpenNebula gate'},
+              {'name': 'opennebula-flow.service', 'desc': 'OpenNebula flow'},
+              {'name': 'opennebula-fireedge.service', 'desc': 'OpenNebula Fireedge GUI'}
+            ]),
+            'check_fireedge_ui': validation.core_services.check_fireedge_ui | default(true)
+          }, recursive=True)
         }, recursive=True)
       }}
 
 - name: Run core infrastucture verification test
   ansible.builtin.include_tasks:
     file: "{{ role_path }}/tasks/core_services_verification.yml"
-  when: validation.core_services
+  when: validation.run_core_services
 


### PR DESCRIPTION
## Summary
- reorganize validation variables into scoped groups for HA, core services, and test VM
- update roles and playbooks to consume `validation.test_vm` and `validation.core_services`

## Testing
- `ansible-playbook --syntax-check playbooks/validation.yml`
- `ansible-playbook --syntax-check playbooks/fe-ha.yml`
- `ansible-playbook --syntax-check playbooks/prepare-test-vm-template.yml`
- `ansible-playbook --syntax-check playbooks/cleanup-test-vm-template.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a5c137565c8333810a07d80e9b3371